### PR TITLE
add chmod g+w * to rule merge_vcfs 

### DIFF
--- a/rules/varscan/Snakefile
+++ b/rules/varscan/Snakefile
@@ -363,6 +363,7 @@ rule merge_vcfs:
         " {input.indel}"
         ' > {output}'
         " 2> {log}"
+        " && chmod -v g+w {output} 2>> {log}"
 
         # #merge the vcfs
         # echo merging vcfs for $OUTPUTBASENAME


### PR DESCRIPTION
after testing i got this
mode of ‘/home/dealz101/gpfs/Intermediate/160_merge_vcfs/Keimbahn/KB0230.fpcorr.snp_indel.vcf’
changed from 0644 (rw-r--r--) to 0664 (rw-rw-r--)
i will apply this change to all rule at a shell call