### PR TITLE
added a test for helper function _run2date

### DIFF
--- a/scripts/parse_samplesheet.py
+++ b/scripts/parse_samplesheet.py
@@ -527,8 +527,8 @@ def get_reference_varscan_somatic(sample, samplesheets, config):
 def _run2date(run):
     date='%04i/%02i/%02i' % (
         int(run.split('_')[0][:2])+2000,
-        int(run.split('_')[0][3:4]),
-        int(run.split('_')[0][5:6]))
+        int(run.split('_')[0][2:4]),
+        int(run.split('_')[0][4:6]))
     return date
 
 

--- a/scripts/tests/test_parse_samplesheet.py
+++ b/scripts/tests/test_parse_samplesheet.py
@@ -3,6 +3,7 @@ sys.path.append("..")
 
 from unittest import TestCase, main
 from scripts.parse_samplesheet import *
+from scripts.parse_samplesheet import _run2date
 import yaml
 from io import StringIO
 
@@ -321,6 +322,15 @@ class ParseSamplesheetTests(TestCase):
                      'spike_entity_id': None,
                      'spike_entity_role': None}]
             validate_samplesheet(pd.DataFrame(data), self.config)
+
+
+class HelperFunctions(TestCase):
+    def test__run2date(self):
+        # Deya: I have tested this function for the following run
+        self.assertEqual('2019/10/09', _run2date('191009_SN737_0479_ACDU95ACXX'))
+        self.assertEqual('2019/08/21', _run2date('190821_SN737_0472_BCDPEFACXX'))
+        # Stefan
+        self.assertEqual('2012/03/23', _run2date('120323_SN737_0172_BC0G9NACXX'))
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_parse_samplesheet.py
+++ b/scripts/tests/test_parse_samplesheet.py
@@ -331,6 +331,16 @@ class HelperFunctions(TestCase):
         self.assertEqual('2019/08/21', _run2date('190821_SN737_0472_BCDPEFACXX'))
         # Stefan
         self.assertEqual('2012/03/23', _run2date('120323_SN737_0172_BC0G9NACXX'))
+        self.assertEqual('2012/08/01', _run2date('120801_SN737_0199_AC0TNHACXX'))
+        self.assertEqual('2014/11/23', _run2date('141123_M02092_0031_000000000-ABGCR'))
+        self.assertEqual('2016/06/09', _run2date('160609_SN737_0385_AC8N1RACXX'))
+        self.assertEqual('2017/07/25', _run2date('170725_SN737_0416_BCAD2RACXX'))
+        self.assertEqual('2018/09/13', _run2date('180913_M04304_0134_000000000-C45VP'))
+        self.assertEqual('2018/09/20', _run2date('180920_SN737_0447_ACC9UWACXX'))
+        self.assertEqual('2019/08/02', _run2date('190802_SN737_0470_ACDT87ACXX'))
+        self.assertEqual('2019/08/02', _run2date('190802_SN737_0471_BCDPE4ACXX'))
+        self.assertEqual('2018/09/06', _run2date('180906_M04304_0133_000000000-C2VLP'))
+        self.assertEqual('2018/09/20', _run2date('180920_SN737_0448_BCC9V5ACXX'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I introduced a stupid bug in the function that parses dates from the "run" string, i.e. chose the wrong subscripts (see issue #210). That is very unfortunate as I don't know in how many samples this wrong date is now encoded :-/
On the other hand, this is a wonderful - because its small - example why you should always have unit-tests in place, which I had not.

With this PR, you see the ideal procedure: 1) create a new test that replicates the reported wrong behaviour and leads to a failing test (29ec512) 2) fix the bug and show that tests now pass (1128d31).