### PR TITLE
added -p {threads}

### DIFF
--- a/rules/rejoin_samples/Snakefile
+++ b/rules/rejoin_samples/Snakefile
@@ -24,7 +24,7 @@ rule rejoin_sample:
         # NO, you cannot!
         #' cat {params.single_fastqs} > {output} 2> {log};'
         ' zcat {params.single_fastqs}'
-        ' | pigz --blocksize 1024 -6 --stdout '
+        ' | pigz --blocksize 1024 -6 --stdout -p {threads}'
         ' | dd > {output} 2>> {log}; '
         ' else'
         ' cp -l -v {params.single_fastqs} {output} 2> {log} 1>&2;'


### PR DESCRIPTION
to address #222, I added the `-p {threads} argument` to the pigz call. Note that `threads: 1` is the default, but can be dynamically overwritten by the cluster.yaml configuration. Thus, this is a more clean solution than just writing `-p 1`.